### PR TITLE
libsodium is no longer used as it is integrated as a static library i…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,6 @@ NodeJs should be installed
 
  3. Copy the `libc_wrapper.{so, dylib}` from the `target/release` folder to the `data` folder of the `Safe-Addon`
 
- 4. For linux, add the libsodium dependency in the `data` folder. Add `libsodium.so.<version>` instead of `libsodium.so`
-
 ## Packaging the API:
   Execute `jpm xpi` to get the @safe_addon.xpi file
 


### PR DESCRIPTION
…n libsafe_ffi.so on Linux.
